### PR TITLE
Improve PHP highlighting

### DIFF
--- a/colors/darcula.vim
+++ b/colors/darcula.vim
@@ -510,3 +510,26 @@ hi! link shOperator NormalFg
 
 " help
 hi! link helpHyperTextJump Number
+
+" PHP
+if has("autocmd")
+	autocmd BufEnter *.php call s:Hi('Normal', s:p.fg, s:p.templateLanguage)
+endif
+hi! link phpFunctions Normal
+hi! link phpFunction function
+hi! link phpMethod function
+hi! link phpIdentifier constant
+hi! link phpMethodsVar constant
+hi! link phpInclude keyword
+hi! link phpBoolean keyword
+hi! link phpSpecialChar keyword
+hi! link phpParent Normal
+hi! link phpOperator Normal
+hi! link phpMemberSelector Normal
+hi! link phpStaticClasses Normal
+hi! link phpDocComment docComment
+hi! link phpDocParam docComment
+hi! link phpDocIdentifier docComment
+hi! link phpCommentStar docComment
+hi! link phpCommentTitle docComment
+call s:Hi('phpDocTags', s:p.docComment, s:p.null, 'bold,italic,underline')


### PR DESCRIPTION
Add PHP specific adjustments that make it closer to PhpStorm's colors

Before:
![before](https://user-images.githubusercontent.com/490653/81453938-2fffdb00-918b-11ea-8f11-2db4d9b58fb0.png)

After:
![after](https://user-images.githubusercontent.com/490653/81453949-355d2580-918b-11ea-93b4-e335398e2d92.png)

PhpStorm:
![phpstorm](https://user-images.githubusercontent.com/490653/81453958-38f0ac80-918b-11ea-8ccb-e3be1fc26122.png)
