### PR TITLE
minor tree-sitter corrections

### DIFF
--- a/colors/darcula.vim
+++ b/colors/darcula.vim
@@ -284,7 +284,7 @@ if has('nvim')
   let g:terminal_color_15 = s:p.ANSIWhite[0]
 
   " Tree-sitter
-  hi! link TSAnnotation Normal
+  hi! link TSAnnotation PreProc
   hi! link TSAttribute Normal
   hi! link TSBoolean Keyword
   hi! link TSCharacter Character
@@ -301,13 +301,13 @@ if has('nvim')
   hi! link TSFunction Function
   hi! link TSFuncBuiltin Normal
   hi! link TSFuncMacro cMacroName
-  hi! link TSInclude PreProc
+  hi! link TSInclude Keyword
   hi! link TSKeyword Keyword
   hi! link TSKeywordFunction Keyword
   hi! link TSLabel Normal
   hi! link TSMethod Function
   hi! link TSNamespace cDataStructure
-  hi! link TSNone Keyword
+  hi! link TSNone Normal
   hi! link TSNumber Number
   hi! link TSOperator Normal
   hi! link TSParameter Normal

--- a/colors/darcula.vim
+++ b/colors/darcula.vim
@@ -285,7 +285,7 @@ if has('nvim')
 
   " Tree-sitter
   hi! link TSAnnotation PreProc
-  hi! link TSAttribute Normal
+  hi! link TSAttribute PreProc
   hi! link TSBoolean Keyword
   hi! link TSCharacter Character
   hi! link TSComment Comment


### PR DESCRIPTION
Just a few minor corrections, when comparing to Intellij at least:

- Intellj uses the PreProc color for annotations
- `import`, `package` in kotlin is highlighted as keywords are. (similary to `use` in rust, like in the screenshot in the README) 
- TSNone is used in tree-sitter for resetting highlighting